### PR TITLE
Add 'unlisted' status option to asset modals and update status display

### DIFF
--- a/src/components/AddAssetModal.tsx
+++ b/src/components/AddAssetModal.tsx
@@ -378,8 +378,8 @@ export default function AddAssetModal() {
                 className="col-span-3 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background"
               >
                 <option value="available">Available</option>
-                <option value="borrowed">Borrowed</option>
                 <option value="in_repair">In Repair</option>
+                <option value="unlisted">Unlisted</option>
               </select>
             </div>
             <div className="grid grid-cols-4 items-center gap-4">

--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -32,14 +32,20 @@ export function AssetCard({ asset, onToggleFavorite, onDelete, onEdit }: AssetCa
       case 'borrowed':
         return 'bg-yellow-100 text-yellow-800';
       case 'in_repair':
-        return 'bg-red-100 text-red-800';
+        return 'bg-yellow-100 text-yellow-800';
+      case 'unlisted':
+        return 'bg-gray-100 text-gray-800';
       default:
         return 'bg-gray-100 text-gray-800';
     }
   };
 
   return (
-    <div className="group relative overflow-hidden rounded-lg border bg-white shadow-sm transition-shadow hover:shadow-md">
+    <div
+      className={`group relative overflow-hidden rounded-lg border bg-white shadow-sm transition-shadow hover:shadow-md ${
+        asset.status === 'unlisted' ? 'opacity-50' : ''
+      }`}
+    >
       <Link to="/assets/my-assets/$id" params={{ id: asset.id }} className="block">
         <div className="aspect-square overflow-hidden">
           <img
@@ -59,7 +65,12 @@ export function AssetCard({ asset, onToggleFavorite, onDelete, onEdit }: AssetCa
               </Link>
             </h3>
           </div>
-          <Badge className={`ml-2 shrink-0 ${getStatusColor()}`}>{asset.status}</Badge>
+          <Badge className={`ml-2 shrink-0 ${getStatusColor()}`}>
+            {asset.status
+              .split('_')
+              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+              .join(' ')}
+          </Badge>
         </div>
       </div>
       <button

--- a/src/components/EditAssetModal.tsx
+++ b/src/components/EditAssetModal.tsx
@@ -185,8 +185,8 @@ export function EditAssetModal({
                 className="col-span-3 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
               >
                 <option value="available">Available</option>
-                <option value="borrowed">Borrowed</option>
                 <option value="in_repair">In Repair</option>
+                <option value="unlisted">Unlisted</option>
               </select>
             </div>
             <div className="grid grid-cols-4 items-center gap-4">

--- a/src/routes/assets/my-assets/index.tsx
+++ b/src/routes/assets/my-assets/index.tsx
@@ -215,8 +215,8 @@ function MyAssetsComponent() {
               <SelectContent>
                 <SelectItem value="all">All Statuses</SelectItem>
                 <SelectItem value="available">Available</SelectItem>
-                <SelectItem value="borrowed">Borrowed</SelectItem>
                 <SelectItem value="in_repair">In Repair</SelectItem>
+                <SelectItem value="unlisted">Unlisted</SelectItem>
               </SelectContent>
             </Select>
             <Button


### PR DESCRIPTION
Introduce an 'unlisted' status for assets in modals and update the display logic to reflect this new status. Adjust the appearance of asset cards based on their status.